### PR TITLE
Fix Title line height issue when scaled heading is enabled

### DIFF
--- a/src/styles/scaled-headings.scss
+++ b/src/styles/scaled-headings.scss
@@ -16,6 +16,10 @@
 			font-size: var(--iceberg--typography--heading--scale-6) !important;
 		}
 
+		.editor-post-title__input {
+			line-height: var(--iceberg--typography--heading--scale-6) !important;
+		}
+
 		h2 {
 			font-size: var(--iceberg--typography--heading--scale-5) !important;
 		}


### PR DESCRIPTION
### Description
Fix Title line height issue when scaled heading is enabled

### Screenshots
<img width="876" alt="Screen Shot 2020-08-05 at 9 41 41 PM" src="https://user-images.githubusercontent.com/3365507/89419923-98e3f880-d764-11ea-8cc6-11c930ee89ea.png">
