### PR TITLE
Fix permission_callback

### DIFF
--- a/includes/class-iceberg-license-handler.php
+++ b/includes/class-iceberg-license-handler.php
@@ -58,7 +58,7 @@ class Iceberg_License_Handler {
 					'/license/(?P<action>[a-zA-Z0-9-]+)/(?P<license>[a-zA-Z0-9-]+)',
 					array(
 						'methods'              => 'POST',
-						'permissions_callback' => array( $this, 'permissions' ),
+						'permission_callback' => array( $this, 'permissions' ),
 						'args'                 => array(
 							'action'  => array(
 								'required'          => true,


### PR DESCRIPTION
In a fresh install of Iceberg, QueryMonitor flags the following when the Google Sitekit plugin is active:

> `register_rest_route` was called incorrectly. The REST API route definition for `iceberg/v1/license/(?P[a-zA-Z0-9-]+)/(?P[a-zA-Z0-9-]+)` is missing the required permission_callback argument. For REST API routes that are intended to be public, use `__return_true` as the permission callback. Please see Debugging in WordPress for more information. (This message was added in version 5.5.0.)

Location:

```
wp-includes/functions.php:5311
register_rest_route()
wp-content/plugins/iceberg/includes/class-iceberg-license-handler.php:72
```

Checking `iceberg/includes/class-iceberg-license-handler.php`, I see that the callback is `permissions_callback` instead of `permission_callback`. This PR fixes what appears to be a typo with the callback.

Reference: https://developer.wordpress.org/rest-api/extending-the-rest-api/adding-custom-endpoints/#permissions-callback